### PR TITLE
fix liquid tag in post layout, which causes build warnings

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
    
     <article class="module color-3">
        
-        <h1>{{ page.title }}{{ .shortUrl }}</h1>
+        <h1>{{ page.title }}{{ page.shortUrl }}</h1>
         <div class='separator'></div>
         
         {{ content }}


### PR DESCRIPTION
In the latest stable Jekyll (3.4) performing a `jekyll build` on the vanilla theme results in the following build warning:

```
Liquid Warning: Liquid syntax error (line 5): [:dot, "."] is not a valid expression in "{{ .shortUrl }}" in /_layouts/post.html
Liquid Warning: Liquid syntax error (line 5): [:dot, "."] is not a valid expression in "{{ .shortUrl }}" in /_layouts/post.html
Liquid Warning: Liquid syntax error (line 5): [:dot, "."] is not a valid expression in "{{ .shortUrl }}" in /_layouts/post.html
```